### PR TITLE
Add relay map with no interactions as captains map

### DIFF
--- a/src/playerInfo.cpp
+++ b/src/playerInfo.cpp
@@ -192,7 +192,7 @@ void PlayerInfo::spawnUI(int monitor_index, RenderLayer* render_layer)
         if (crew_position[scienceOfficer] & (1 << monitor_index))
             screen->addStationTab(new ScienceScreen(container), scienceOfficer, getCrewPositionName(scienceOfficer), getCrewPositionIcon(scienceOfficer));
         if (crew_position[relayOfficer] & (1 << monitor_index))
-            screen->addStationTab(new RelayScreen(container, true), relayOfficer, getCrewPositionName(relayOfficer), getCrewPositionIcon(relayOfficer));
+            screen->addStationTab(new RelayScreen(container, RelayScreen::Variant::relay), relayOfficer, getCrewPositionName(relayOfficer), getCrewPositionIcon(relayOfficer));
 
         //Crew 4/3
         if (crew_position[tacticalOfficer] & (1 << monitor_index))
@@ -214,11 +214,13 @@ void PlayerInfo::spawnUI(int monitor_index, RenderLayer* render_layer)
         if (crew_position[databaseView] & (1 << monitor_index))
             screen->addStationTab(new DatabaseScreen(container), databaseView, getCrewPositionName(databaseView), getCrewPositionIcon(databaseView));
         if (crew_position[altRelay] & (1 << monitor_index))
-            screen->addStationTab(new RelayScreen(container, false), altRelay, getCrewPositionName(altRelay), getCrewPositionIcon(altRelay));
+            screen->addStationTab(new RelayScreen(container, RelayScreen::Variant::stategic_map), altRelay, getCrewPositionName(altRelay), getCrewPositionIcon(altRelay));
         if (crew_position[commsOnly] & (1 << monitor_index))
             screen->addStationTab(new CommsScreen(container), commsOnly, getCrewPositionName(commsOnly), getCrewPositionIcon(commsOnly));
         if (crew_position[shipLog] & (1 << monitor_index))
             screen->addStationTab(new ShipLogScreen(container), shipLog, getCrewPositionName(shipLog), getCrewPositionIcon(shipLog));
+        if (crew_position[captainsMap] & (1 << monitor_index))
+            screen->addStationTab(new RelayScreen(container, RelayScreen::Variant::captains_map), captainsMap, getCrewPositionName(captainsMap), getCrewPositionIcon(captainsMap));
 
         GuiSelfDestructEntry* sde = new GuiSelfDestructEntry(container, "SELF_DESTRUCT_ENTRY");
         for(int n=0; n<max_crew_positions; n++)
@@ -265,6 +267,7 @@ string getCrewPositionName(ECrewPosition position)
     case altRelay: return tr("station","Strategic Map");
     case commsOnly: return tr("station","Comms");
     case shipLog: return tr("station","Ship's Log");
+    case captainsMap: return tr("station","Captains Map");
     default: return "ErrUnk: " + string(position);
     }
 }
@@ -288,6 +291,7 @@ string getCrewPositionIcon(ECrewPosition position)
     case altRelay: return "";
     case commsOnly: return "";
     case shipLog: return "";
+    case captainsMap: return "";
     default: return "ErrUnk: " + string(position);
     }
 }
@@ -334,6 +338,8 @@ template<> void convert<ECrewPosition>::param(lua_State* L, int& idx, ECrewPosit
         cp = commsOnly;
     else if (str == "shiplog")
         cp = shipLog;
+    else if (str == "captainsmap")
+        cp = captainsMap;
     else
         luaL_error(L, "Unknown value for crew position: %s", str.c_str());
 }

--- a/src/playerInfo.h
+++ b/src/playerInfo.h
@@ -25,6 +25,7 @@ enum ECrewPosition
     altRelay,
     commsOnly,
     shipLog,
+    captainsMap,
     max_crew_positions
 };
 

--- a/src/screens/crew6/relayScreen.h
+++ b/src/screens/crew6/relayScreen.h
@@ -14,6 +14,14 @@ class GuiHackingDialog;
 
 class RelayScreen : public GuiOverlay
 {
+public:
+    enum class Variant
+    {
+        relay,
+        stategic_map,
+        captains_map
+    };
+
 private:
     enum EMode
     {
@@ -45,8 +53,11 @@ private:
     GuiHackingDialog* hacking_dialog;
 
     glm::vec2 mouse_down_position{};
+
+    Variant variant;
+
 public:
-    RelayScreen(GuiContainer* owner, bool allow_comms);
+    RelayScreen(GuiContainer* owner, Variant variant);
 
     virtual void onDraw(sp::RenderTarget& target) override;
 };

--- a/src/tutorialGame.cpp
+++ b/src/tutorialGame.cpp
@@ -84,7 +84,7 @@ void TutorialGame::createScreens()
     station_screen[1] = new WeaponsScreen(this);
     station_screen[2] = new EngineeringScreen(this);
     station_screen[3] = new ScienceScreen(this);
-    station_screen[4] = new RelayScreen(this, true);
+    station_screen[4] = new RelayScreen(this, RelayScreen::Variant::relay);
     station_screen[5] = new TacticalScreen(this);
     station_screen[6] = new EngineeringAdvancedScreen(this);
     station_screen[7] = new OperationScreen(this);


### PR DESCRIPTION
Gives the captains laptop something to display when he is not just providing the main screen. Arguably makes the captains role easyer as he needs to communicate less with relay.

This patch has a desgin bug that I'm not really sure how to fix: the new entry in alternative options sections in the ship station select screen does not fit the current layout. (and as such only the upper pixel row of the button is clickable). Any idea on how to make this look right again and make the button clickable in whole?